### PR TITLE
New wardround

### DIFF
--- a/config/karma.conf.travis.js
+++ b/config/karma.conf.travis.js
@@ -57,6 +57,7 @@ module.exports = function(config){
             // '../../../../elcid/elcid/assets/js/elcid/*.js',
             __dirname+'/../wardround/static/js/wardround/*.js',
             __dirname+'/../wardround/static/js/wardround/controllers/*.js',
+            __dirname+'/../wardround/static/js/wardround/services/*.js',
             __dirname+'/../wardround/static/js/test/*.js',
 
             // 'opaltest/*.js',

--- a/wardround/static/js/test/find.patient.controller.test.js
+++ b/wardround/static/js/test/find.patient.controller.test.js
@@ -27,11 +27,6 @@ describe('WardRoundFindPatientCtrl', function (){
         });
     }));
 
-    afterEach(function() {
-        $httpBackend.verifyNoOutstandingExpectation();
-        $httpBackend.verifyNoOutstandingRequest();
-    });
-
     describe('get_filtered_episodes()', function (){
 
         it('Should allow all episodes when the query is ""', function () {

--- a/wardround/static/js/wardround/app.js
+++ b/wardround/static/js/wardround/app.js
@@ -45,9 +45,9 @@ app.config(function($routeProvider){
                 episode: function(episodeLoader){
                     return episodeLoader();
                 },
-                episodeIds: function(WardRoundUtils, $route, $location){
+                wardroundDetail: function(WardRoundUtils, $route, $location){
                     var w = new WardRoundUtils($route.current.params.wardround, $location.search());
-                    return w.getEpisodesIds();
+                    return w.getWardroundDetail();
                 },
             		options: function(Options) { return Options; },
                 profile: function(UserProfile){ return UserProfile }

--- a/wardround/static/js/wardround/controllers/episode_detail.js
+++ b/wardround/static/js/wardround/controllers/episode_detail.js
@@ -3,25 +3,29 @@
 //
 angular.module('opal.wardround.controllers').controller(
   'WardRoundDetailCtrl', function($rootScope, $scope, $routeParams, $location,
-    $cookieStore, $modal, episode, episodeIds, $modalStack,
+    $cookieStore, $modal, episode, wardroundDetail, $modalStack,
     EpisodeDetailMixin, Flow, options, profile, WardRoundUtils){
       "use strict";
 
-      if(!_.contains(episodeIds, episode.id)){
+      if(!_.contains(wardroundDetail.episodeIds, episode.id)){
           $location.url("/" + $routeParams.wardround);
           $location.replace();
       }
       var wardRoundUtils = new WardRoundUtils($routeParams.wardround, $location.search());
+
       $modalStack.dismissAll();
-      var wardRoundName = $routeParams.wardround;
       $scope.episode = episode;
+
+      // this is currently used by some of the actions to figure out if we're in
+      // a wardround. Its also used to add the title
+      $scope.ward_round = wardroundDetail;
       $scope.options = options;
       $scope.profile = profile;
       $scope.Flow = Flow;
       EpisodeDetailMixin($scope);
       $scope.wardRoundOrderCollapsed = true;
-      $scope.episodeNumber = _.indexOf(episodeIds, $scope.episode.id);
-      $scope.totalEpisodes = episodeIds.length;
+      $scope.episodeNumber = _.indexOf(wardroundDetail.episodeIds, $scope.episode.id);
+      $scope.totalEpisodes = wardroundDetail.episodeIds.length;
 
       $scope.findPatient = function(){
         $rootScope.state = 'modal';
@@ -49,13 +53,13 @@ angular.module('opal.wardround.controllers').controller(
       $scope.next = false;
 
       if($scope.episodeNumber + 1 !== $scope.totalEpisodes){
-          $scope.next = wardRoundUtils.getEpisodeLink(episodeIds[$scope.episodeNumber + 1]);
+          $scope.next = wardRoundUtils.getEpisodeLink(wardroundDetail.episodeIds[$scope.episodeNumber + 1]);
       }
 
       $scope.previous = false;
 
       if($scope.episodeNumber !== 0){
-          $scope.previous = wardRoundUtils.getEpisodeLink(episodeIds[$scope.episodeNumber - 1]);
+          $scope.previous = wardRoundUtils.getEpisodeLink(wardroundDetail.episodeIds[$scope.episodeNumber - 1]);
       }
     }
   );

--- a/wardround/static/js/wardround/controllers/episode_detail.js
+++ b/wardround/static/js/wardround/controllers/episode_detail.js
@@ -61,18 +61,5 @@ angular.module('opal.wardround.controllers').controller(
       if($scope.episodeNumber !== 0){
           $scope.previous = wardRoundUtils.getEpisodeLink(wardroundDetail.episodeIds[$scope.episodeNumber - 1]);
       }
-
-      $scope.named_controller = function(template, controller){
-          $modal.open({
-              templateUrl: template,
-              controller: controller,
-              resolve: {
-                  episode: function(){ return $scope.episode; },
-                  tags: function(){ return {};  },
-                  schema: function(){ return {}; },
-                  options: function(){ return options; }
-              }
-          });
-      };
     }
   );

--- a/wardround/static/js/wardround/controllers/episode_detail.js
+++ b/wardround/static/js/wardround/controllers/episode_detail.js
@@ -61,5 +61,18 @@ angular.module('opal.wardround.controllers').controller(
       if($scope.episodeNumber !== 0){
           $scope.previous = wardRoundUtils.getEpisodeLink(wardroundDetail.episodeIds[$scope.episodeNumber - 1]);
       }
+
+      $scope.named_controller = function(template, controller){
+          $modal.open({
+              templateUrl: template,
+              controller: controller,
+              resolve: {
+                  episode: function(){ return $scope.episode; },
+                  tags: function(){ return {};  },
+                  schema: function(){ return {}; },
+                  options: function(){ return options; }
+              }
+          });
+      };
     }
   );

--- a/wardround/static/js/wardround/controllers/wardround.js
+++ b/wardround/static/js/wardround/controllers/wardround.js
@@ -8,6 +8,11 @@ angular.module('opal.wardround.controllers').controller(
       "use strict";
       $scope.ready = false;
 
+      // we clear out the cache so that if the user was to add a patient
+      // then look at the wardround the cache would be cleaned appropriately
+      var wardroundUtils = new WardRoundUtils($routeParams.wardround, $location.search());
+      wardroundUtils.cleanLocalStorage();
+
       $scope.wardround = wardround;
       $scope.filters = $location.search();
       $scope.episodes = wardround.episodes;


### PR DESCRIPTION
The bulk of the changes are because we used to just store episode ids in the cache object, now we store the name of the wardround too as we used to use this in the episode detail. Cue heavy refactoring

also more unit test fixes and unit test fixes