### PR TITLE
55 wardround ordering

### DIFF
--- a/wardround/tests/test_wardrounds.py
+++ b/wardround/tests/test_wardrounds.py
@@ -160,7 +160,8 @@ class WardroundTest(OpalTestCase):
             self.assertEqual(found_ids, [1, 2])
 
     def test_default_wardround_ordering(self):
-        """ default ordering should be done by hospital_number
+        """ default ordering should be done by the first column in the
+            wardround table
         """
         patient, episode = self.new_patient_and_episode_please()
         patient.demographics_set.update(hospital_number=15)

--- a/wardround/wardrounds.py
+++ b/wardround/wardrounds.py
@@ -66,10 +66,14 @@ class WardRound(BaseWardRound):
         field_dict_copy = copy(field_dict)
         field_dict_copy["id"] = "id"
 
-        episodes = episodes.order_by(list(field_dict)[0])
+        if not episodes.ordered:
+            episodes = episodes.order_by(list(field_dict)[0])
         episodes = episodes.values(*field_dict_copy.keys())
         episodes = [
-            {field_dict_copy[k]: v for k, v in episode.items()} for episode in episodes]
+            {
+                field_dict_copy[k]: v for k, v in episode.items()
+            } for episode in episodes
+        ]
 
         columns = list(field_dict.values())
 


### PR DESCRIPTION
fixes #55 we now respect whatever order of episodes we are given, unless its not ordered, in which case you the first field in the table display, which by default is hospital number.

Note this is going into 10, we can release on a 9.1 branch if you'd prefer
  